### PR TITLE
Support GRSEC patched kernels

### DIFF
--- a/src/module_notifier_event.c
+++ b/src/module_notifier_event.c
@@ -1,6 +1,7 @@
 #include <linux/notifier.h>
 #include <linux/spinlock.h>
 #include <linux/module.h>
+#include <linux/vermagic.h>
 #include "module_notifier_event.h"
 
 int fail(void)
@@ -23,10 +24,19 @@ static int dresden_module_handler(struct notifier_block *this, unsigned long eve
 	switch(new_module->state)
 	{
 		case(MODULE_STATE_COMING):
+#ifndef MODULE_GRSEC
 					printk(KERN_EMERG MODULE_NAME ": event: MODULE_STATE_COMING name: %s init: 0x%p size of init (text + data)\
 													0x%x core: 0x%p size of core (text + data) 0x%x\n",
 													new_module->name, new_module->init, new_module->init_size,
 													new_module->module_core, new_module->core_size);
+#else /* MODULE_GRSEC */
+					printk(KERN_EMERG MODULE_NAME ": event: MODULE_STATE_COMING name: %s, int: 0x%p, init_rx: 0x%p (size 0x%x), init_rw: 0x%p (size 0x%x), core_rx: 0x%p (size 0x%x), core_rw: 0x%p (size 0x%x)\n",
+													new_module->name, new_module->init,
+													new_module->module_init_rx, new_module->init_size_rx,
+													new_module->module_init_rw, new_module->init_size_rw,
+													new_module->module_core_rx, new_module->core_size_rx,
+													new_module->module_core_rw, new_module->core_size_rw);
+#endif /* MODULE_GRSEC */
 					new_module->init = fail;
 
 					printk(KERN_EMERG MODULE_NAME ": New module name is '%s'. Its functionality will be disabled\n", new_module->name);
@@ -39,12 +49,26 @@ static int dresden_module_handler(struct notifier_block *this, unsigned long eve
 				break;
 			}
 
+#ifndef MODULE_GRSEC
                         printk(KERN_EMERG MODULE_NAME ": event: MODULE_STATE_LIVE name: %s core: 0x%p size of core (text + data) 0x%x\n",
                         										new_module->name, new_module->module_core, new_module->core_size);
+#else /* MODULE_GRSEC */
+                        printk(KERN_EMERG MODULE_NAME ": event: MODULE_STATE_LIVE name: %s, core_rx: 0x%p (size 0x%x), core_rw: 0x%p (size 0x%x)\n",
+                        										new_module->name,
+													new_module->module_core_rx, new_module->core_size_rx,
+													new_module->module_core_rw, new_module->core_size_rw);
+#endif /* MODULE_GRSEC */
                         break;		
 		case(MODULE_STATE_GOING):
+#ifndef MODULE_GRSEC
 			printk(KERN_EMERG MODULE_NAME ": event: MODULE_STATE_GOING name: %s core: 0x%p size of core (text + data) 0x%x\n",
 													new_module->name, new_module->module_core, new_module->core_size);
+#else /* MODULE_GRSEC */
+			printk(KERN_EMERG MODULE_NAME ": event: MODULE_STATE_GOING name: %s core: 0x%p (size 0x%x), core_rw: 0x%p (size 0x%x)\n",
+													new_module->name,
+													new_module->module_core_rx, new_module->core_size_rx,
+													new_module->module_core_rw, new_module->core_size_rw);
+#endif /* MODULE_GRSEC */
 			break;
 		default:
 			printk(KERN_ERR MODULE_NAME ": ERROR unknown module state in notifier chain for %s module\n", new_module->name);

--- a/src/module_notifier_event.c
+++ b/src/module_notifier_event.c
@@ -24,12 +24,12 @@ static int dresden_module_handler(struct notifier_block *this, unsigned long eve
 	{
 		case(MODULE_STATE_COMING):
 					printk(KERN_EMERG MODULE_NAME ": event: MODULE_STATE_COMING name: %s init: 0x%p size of init (text + data)\
-													0x%x core: 0x%p size of core (text + data) 0x%x\n", 
-													new_module->name, new_module->init, new_module->init_size, 
+													0x%x core: 0x%p size of core (text + data) 0x%x\n",
+													new_module->name, new_module->init, new_module->init_size,
 													new_module->module_core, new_module->core_size);
 					new_module->init = fail;
 
-					printk(KERN_EMERG MODULE_NAME ": New module is th name %s. Its functionality will be disabled\n", new_module->name);
+					printk(KERN_EMERG MODULE_NAME ": New module name is '%s'. Its functionality will be disabled\n", new_module->name);
 			break;
 		case(MODULE_STATE_LIVE):
 			if(new_module == THIS_MODULE)
@@ -39,11 +39,11 @@ static int dresden_module_handler(struct notifier_block *this, unsigned long eve
 				break;
 			}
 
-                        printk(KERN_EMERG MODULE_NAME ": event: MODULE_STATE_LIVE name: %s core: 0x%p size of core (text + data) 0x%x\n", 
+                        printk(KERN_EMERG MODULE_NAME ": event: MODULE_STATE_LIVE name: %s core: 0x%p size of core (text + data) 0x%x\n",
                         										new_module->name, new_module->module_core, new_module->core_size);
                         break;		
 		case(MODULE_STATE_GOING):
-			printk(KERN_EMERG MODULE_NAME ": event: MODULE_STATE_GOING name: %s core: 0x%p size of core (text + data) 0x%x\n", 
+			printk(KERN_EMERG MODULE_NAME ": event: MODULE_STATE_GOING name: %s core: 0x%p size of core (text + data) 0x%x\n",
 													new_module->name, new_module->module_core, new_module->core_size);
 			break;
 		default:


### PR DESCRIPTION
The current grsecurity patch split the data and the init of a module into a rx path and a rw one.
This fix changes the different things printed on load in order to support those new size/pointers.

Compatibility with vanilla kernels is guaranteed by a #ifndef MODULE_GRSEC since MODULE_GRSEC is defined in linux/vermagic.h for grsec-patched kernels and not for vanilla ones
